### PR TITLE
Removed 'require.paths.unshift...'

### DIFF
--- a/bin/http-console
+++ b/bin/http-console
@@ -3,8 +3,6 @@
 var path = require('path'),
     sys = require('util');
 
-require.paths.unshift(path.join(__dirname, '..', 'lib'));
-
 var httpConsole = require('http-console');
 
 var help = [


### PR DESCRIPTION
Removed 'require.paths.unshift….' to make http-console work with node 0.6.x
