### PR TITLE
Fix `bin/http-console`

### DIFF
--- a/bin/http-console
+++ b/bin/http-console
@@ -3,9 +3,7 @@
 var path = require('path'),
     sys = require('util');
 
-require.paths.unshift(path.join(__dirname, '..', 'lib'));
-
-var httpConsole = require('http-console');
+var httpConsole = require('../lib/http-console');
 
 var help = [
   'usage: http-console [username:password@host:port] [options]',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author"        : "Alexis Sellier <self@cloudhead.net>",
   "contributors"  : [],
   "dependencies"  : { "eyes": ">=0.1.4" },
-  "version"       : "0.6.0",
+  "version"       : "0.6.1",
   "main"          : "./lib/http-console",
   "directories"   : { "lib": "./lib", "test": "./test" },
   "bin"           : { "http-console": "./bin/http-console" },


### PR DESCRIPTION
Remove usage of `require.paths` since it is deprecated since v0.5.2
