### PR TITLE
Load http-console commands on startup

### DIFF
--- a/.http-console
+++ b/.http-console
@@ -1,0 +1,2 @@
+Host: localhost:3000
+Content-Type: application/json

--- a/lib/http-console.js
+++ b/lib/http-console.js
@@ -55,10 +55,51 @@ this.Console.prototype = new(function () {
             process.exit(0);
         });
 
+        this.loadConfig();
+
         this.prompt();
 
         return this;
     };
+
+    /**
+     * Finds and runs http-console commands on start up
+     *
+     * The three locations checked are, in order:
+     *
+     *   1. /etc/.http-console
+     *   2. $HOME/.http-console
+     *   3. $PWD/.http-console
+     *
+     * Commands found in later files overwrite previous ones. Examples of
+     * commands run:
+     *
+     *   Content-Type: application/json
+     *   Authorization: AWS AKIAIOSFODNN7EXAMPLE:frJIUN8DYpKDtOLCwo//yllqDzg=
+     *
+     */
+    this.loadConfig = function() {
+        var that  = this;
+        var file  = '/.http-console';
+        var paths = [
+            '/etc' + file,
+            process.env['HOME'] + file,
+            process.cwd() + file
+        ];
+
+        paths.forEach(function(path) {
+            if (fs.existsSync(path)) {
+                var data  = fs.readFileSync(path, 'utf-8');
+                var lines = data.split("\n");
+                lines.forEach(function(line) {
+                    if (line.trim() != '') {
+                        that.exec(line);
+                    }
+                })
+            }
+        });
+    };
+
     this.welcome = function () {
         sys.puts("> " + ("http-console " + exports.version).bold,
                  "> Welcome, enter .help if you're lost.",


### PR DESCRIPTION
This patch allows you to place http-console commands on a .http-console
file and run them on startup. The three locations checked are, in order:

```
1. /etc/.http-console
2. $HOME/.http-console
3. $PWD/.http-console
```

Commands found in later files overwrite previous ones.
