### PR TITLE
Ejmr/add http methods

### DIFF
--- a/lib/http-console.js
+++ b/lib/http-console.js
@@ -120,6 +120,36 @@ this.Console.prototype = new(function () {
             that = this,
             match, req;
 
+        /* This utility function accepts a string, 'command', and
+         * returns boolean indicating whether or not that command is a
+         * valid HTTP method, i.e. the methods described in RFC 2616.
+         * All method names should begin with the '|' character except
+         * for the first method.  That way we end up with a regular
+         * expression in the form of
+         *
+         *     /^(GET|POST|PUT...)/
+         *
+         * that we can test against the 'command' variable.
+         */
+        var isHTTPMethod = function (command) {
+            var methods = [
+                "GET",
+                "|POST",
+                "|PUT",
+                "|HEAD",
+                "|DELETE",
+                "|OPTIONS"
+            ];
+
+            var regex = "^("
+
+            methods.forEach(function (method) {
+                regex = regex + method;
+            });
+
+            return (new RegExp(regex + ")", "i")).test(command);
+        }
+
         if (this.pending) {
             req = this.request(this.pending.method, this.pending.path, {
                 'Content-Length' : command.length
@@ -181,7 +211,7 @@ this.Console.prototype = new(function () {
             } else {
                 delete(this.headers[match[1]]);
             }
-        } else if (/^(GET|POST|PUT|HEAD|DELETE|OPTIONS)/i.test(command)) {
+        } else if (isHTTPMethod(command)) {
             command = command.split(/\s+/);
             method  = command.shift().toUpperCase();
             path    = this.path.slice(0);

--- a/lib/http-console.js
+++ b/lib/http-console.js
@@ -138,7 +138,8 @@ this.Console.prototype = new(function () {
                 "|PUT",
                 "|HEAD",
                 "|DELETE",
-                "|OPTIONS"
+                "|OPTIONS",
+                "|PATCH"
             ];
 
             var regex = "^("
@@ -220,7 +221,7 @@ this.Console.prototype = new(function () {
 
             path = ('/' + path.join('/')).replace(/\/+/g, '/');
 
-            if (method === 'PUT' || method === 'POST') {
+            if (method === 'PUT' || method === 'POST' || method === "PATCH") {
                 this.pending = { method: method, path: path };
                 this.dataPrompt();
             } else {

--- a/lib/http-console.js
+++ b/lib/http-console.js
@@ -139,7 +139,9 @@ this.Console.prototype = new(function () {
                 "|HEAD",
                 "|DELETE",
                 "|OPTIONS",
-                "|PATCH"
+                "|PATCH",
+                "|TRACE",
+                "|CONNECT"
             ];
 
             var regex = "^("


### PR DESCRIPTION
These three commits add support for three standard HTTP/1.1 methods that are not recognized by http-console:

1. `PATCH`
2. `TRACE`
3. `CONNECT`

The branch tries to address the issues:

* https://github.com/cloudhead/http-console/pull/43
* https://github.com/cloudhead/http-console/issues/27