### PR TITLE
Set default maxLength for eyes to 0

### DIFF
--- a/lib/http-console.js
+++ b/lib/http-console.js
@@ -10,7 +10,7 @@ var http = require('http'),
 require('./ext');
 
 try {
-    var inspect = require('eyes').inspector();
+    var inspect = require('eyes').inspector({ maxLength: 0 });
 } catch (e) {
     var inspect = function (obj) { sys.puts(sys.inspect(obj).white) }
 }


### PR DESCRIPTION
This avoids json or other output from being truncated.